### PR TITLE
Add `group_controller` method to make sure correct controller is used

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -312,6 +312,10 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     def group_form(group_type=None):
         return 'scheming/organization/group_form.html'
 
+    # use the correct controller (see ckan/ckan#2771)
+    def group_controller(self):
+        return 'organization'
+
     def get_actions(self):
         return {
             'scheming_organization_schema_list':


### PR DESCRIPTION
This method is called in CKAN internally on IGroupForm plugins. The
returned controller is used to generate URLs in the pager.
